### PR TITLE
Force static linking to liblmdb.a

### DIFF
--- a/lmdbjni/src/main/native-package/configure
+++ b/lmdbjni/src/main/native-package/configure
@@ -11408,7 +11408,7 @@ if test "${with_lmdb+set}" = set; then :
       CFLAGS="$CFLAGS -I${withval}"
       CXXFLAGS="$CXXFLAGS -I${withval}"
 
-      LDFLAGS="$LDFLAGS -llmdb -L${withval}"
+      LDFLAGS="$LDFLAGS ${withval}/liblmdb.a"
 
 
 


### PR DESCRIPTION
This is necessary as things stand because we aren't copying the liblmdb.so shared library into the .jars

Without this change, I was getting a test failure due to the lack of a install liblmdb.so on my system:

```
Forking command line: /bin/sh -c cd /Users/mbolingbroke/Programming/lmdbjni/lmdbjni-osx64 && /Library/Java/JavaVirtualMachines/jdk1.8.0_05.jdk/Contents/Home/jre/bin/java -jar /Users/mbolingbroke/Programming/lmdbjni/lmdbjni-osx64/target/surefire/surefirebooter2533088075308177221.jar /Users/mbolingbroke/Programming/lmdbjni/lmdbjni-osx64/target/surefire/surefire3730000935785202270tmp /Users/mbolingbroke/Programming/lmdbjni/lmdbjni-osx64/target/surefire/surefire564253358486982743tmp
Running org.fusesource.lmdbjni.test.EnvTest
Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.084 sec <<< FAILURE!

Results :

Tests in error: 
  testCRUD(org.fusesource.lmdbjni.test.EnvTest): Could not load library. Reasons: [no lmdbjni64-0.1.3-SNAPSHOT in java.library.path, no lmdbjni-0.1.3-SNAPSHOT in java.library.path, no lmdbjni in java.library.path, /private/var/folders/j7/s3_nlw2d185c8wlypw27ywk00000gp/T/liblmdbjni-64-0-4840766876264295725.1: dlopen(/private/var/folders/j7/s3_nlw2d185c8wlypw27ywk00000gp/T/liblmdbjni-64-0-4840766876264295725.1, 1): Library not loaded: liblmdb.so

Tests run: 1, Failures: 0, Errors: 1, Skipped: 0
```

This makes the .jars much easier to use (no need to install lmdb on the system you are running the java app on), and follows the precedent already laid down by the py-lmdb bindings.
