### PR TITLE
Transactions: prefer usage of create[Read/Write]Transaction

### DIFF
--- a/lmdbjni/src/main/java/org/fusesource/lmdbjni/Database.java
+++ b/lmdbjni/src/main/java/org/fusesource/lmdbjni/Database.java
@@ -66,7 +66,7 @@ public class Database extends NativeObject implements AutoCloseable {
    * @return Statistics for a database.
    */
   public Stat stat() {
-    try (Transaction tx = env.createTransaction(true)) {
+    try (Transaction tx = env.createReadTransaction()) {
       return new Stat(stat(tx));
     }
   }
@@ -82,7 +82,7 @@ public class Database extends NativeObject implements AutoCloseable {
    * @see org.fusesource.lmdbjni.Database#drop(Transaction, boolean)
    */
   public void drop(boolean delete) {
-    try (Transaction tx = env.createTransaction()) {
+    try (Transaction tx = env.createWriteTransaction()) {
       drop(tx, delete);
       tx.commit();
     }
@@ -109,7 +109,7 @@ public class Database extends NativeObject implements AutoCloseable {
    */
   public int get(DirectBuffer key, DirectBuffer value) {
     checkArgNotNull(key, "key");
-    try (Transaction tx = env.createTransaction(true)) {
+    try (Transaction tx = env.createReadTransaction()) {
       return get(tx, key, value);
     }
   }
@@ -137,7 +137,7 @@ public class Database extends NativeObject implements AutoCloseable {
    */
   public byte[] get(byte[] key) {
     checkArgNotNull(key, "key");
-    try (Transaction tx = env.createTransaction(true)) {
+    try (Transaction tx = env.createReadTransaction()) {
       return get(tx, key);
     }
   }
@@ -295,7 +295,7 @@ public class Database extends NativeObject implements AutoCloseable {
    */
   public int put(DirectBuffer key, DirectBuffer value, int flags) {
     checkArgNotNull(key, "key");
-    try (Transaction tx = env.createTransaction()) {
+    try (Transaction tx = env.createWriteTransaction()) {
       int ret = put(tx, key, value, flags);
       tx.commit();
       return ret;
@@ -338,7 +338,7 @@ public class Database extends NativeObject implements AutoCloseable {
    */
   public byte[] put(byte[] key, byte[] value, int flags) {
     checkArgNotNull(key, "key");
-    try (Transaction tx = env.createTransaction()) {
+    try (Transaction tx = env.createWriteTransaction()) {
       byte[] ret = put(tx, key, value, flags);
       tx.commit();
       return ret;
@@ -451,7 +451,7 @@ public class Database extends NativeObject implements AutoCloseable {
    */
   public boolean delete(DirectBuffer key, DirectBuffer value) {
     checkArgNotNull(key, "key");
-    try (Transaction tx = env.createTransaction()) {
+    try (Transaction tx = env.createWriteTransaction()) {
       boolean ret = delete(tx, key, value);
       tx.commit();
       return ret;
@@ -484,7 +484,7 @@ public class Database extends NativeObject implements AutoCloseable {
    */
   public boolean delete(byte[] key, byte[] value) {
     checkArgNotNull(key, "key");
-    try (Transaction tx = env.createTransaction()) {
+    try (Transaction tx = env.createWriteTransaction()) {
       boolean ret = delete(tx, key, value);
       tx.commit();
       return ret;

--- a/lmdbjni/src/main/java/org/fusesource/lmdbjni/Env.java
+++ b/lmdbjni/src/main/java/org/fusesource/lmdbjni/Env.java
@@ -375,6 +375,7 @@ public class Env extends NativeObject implements AutoCloseable {
   /**
    * @see org.fusesource.lmdbjni.Env#createTransaction(Transaction, boolean)
    */
+  @Deprecated
   public Transaction createTransaction() {
     return createTransaction(null, false);
   }
@@ -382,6 +383,7 @@ public class Env extends NativeObject implements AutoCloseable {
   /**
    * @see org.fusesource.lmdbjni.Env#createTransaction(Transaction, boolean)
    */
+  @Deprecated
   public Transaction createTransaction(boolean readOnly) {
     return createTransaction(null, readOnly);
   }
@@ -525,7 +527,7 @@ public class Env extends NativeObject implements AutoCloseable {
    * @see org.fusesource.lmdbjni.Env#open(String, int, int)
    */
   public Database openDatabase(String name, int flags) {
-    try (Transaction tx = createTransaction()) {
+    try (Transaction tx = createWriteTransaction()) {
       Database db= openDatabase(tx, name, flags);
       tx.commit();
       return db;

--- a/readme.md
+++ b/readme.md
@@ -133,7 +133,7 @@ try (EntryIterator it = db.seekBackward(key))) {
 Performing [transactional](http://deephacks.org/lmdbjni/apidocs/org/fusesource/lmdbjni/Transaction.html) updates.
 
 ```java
- try (Transaction tx = env.createTransaction()) {
+ try (Transaction tx = env.createWriteTransaction()) {
    db.delete(tx, bytes("Denver"));
    db.put(tx, bytes("Tampa"), bytes("green"));
    db.put(tx, bytes("London"), bytes("red"));
@@ -145,7 +145,7 @@ Working against a snapshot view of the database.
 
 ```java
  // create a read-only transaction...
- try (Transaction tx = env.createTransaction(true)) {
+ try (Transaction tx = env.createReadTransaction()) {
    
    // All read operations will now use the same 
    // consistent view of the data.


### PR DESCRIPTION

I have also found the createTransaction(...) calls confusing and saw that you have also reached the same conclusion by adding createRead/WriteTransaction calls. This pull request deprecates the use of the older API. 