### PR TITLE
LAST_DUP and FIRST_DUP need "copy in"

### DIFF
--- a/lmdbjni/src/main/java/org/fusesource/lmdbjni/JNI.java
+++ b/lmdbjni/src/main/java/org/fusesource/lmdbjni/JNI.java
@@ -664,13 +664,14 @@ class JNI {
     //   MDB_SET:
     //   MDB_SET_KEY:
     //   MDB_SET_RANGE:
+	//	 MDB_LAST_DUP:
+	//	 MDB_FIRST_DUP:
+	
     // In order to be future proof, we assume that unknown ops all need to copy in.
     boolean copyIn = !(op == MDB_FIRST ||
-      op == MDB_FIRST_DUP ||
       op == MDB_GET_CURRENT ||
       op == MDB_GET_MULTIPLE ||
       op == MDB_LAST ||
-      op == MDB_LAST_DUP ||
       op == MDB_NEXT ||
       op == MDB_NEXT_DUP ||
       op == MDB_NEXT_MULTIPLE ||


### PR DESCRIPTION
Without "copy in", key size comes back with size larger than Integer.MAX_VALUE instead of correct key size, causing a crash or throwing an exception.  Removing LAST_DUP and FIRST_DUP from the list of instructions that do not require "copy in" fixes the issue.